### PR TITLE
feat: add weekly missions system

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+VITE_CONFIG_BASE=/data
+VITE_SAVE_DB_NAME=game_saves
+VITE_ENABLE_PWA=true

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2022: true, node: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:vue/vue3-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    parser: '@typescript-eslint/parser',
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  rules: {
+    'vue/multi-word-component-names': 'off'
+  }
+};

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,17 @@
+name: deploy
+on:
+  push:
+    branches: [ main ]
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable && pnpm i && pnpm build
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+*.log
+.DS_Store
+.env.local
+.husky/_

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{ "singleQuote": true, "semi": true, "printWidth": 100 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
-# shootGame
-射击游戏 shoot game
+# Shooter Raising
+
+基于 Vue 3 + TypeScript + Vite + Phaser 的顶视角射击养成游戏原型。
+
+## 开发
+
+本项目使用 pnpm 作为包管理器：
+
+```bash
+pnpm install
+pnpm dev
+```
+
+访问 `/#/battle` 可进入示例战斗场景。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Shooter Raising</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/app/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "shooter-raising",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 5173",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint . --ext .ts,.tsx,.vue",
+    "format": "prettier -w .",
+    "test": "vitest run",
+    "test:ui": "vitest",
+    "e2e": "playwright test",
+    "prepare": "husky install",
+    "deploy:gh": "cross-env NODE_ENV=production vite build && npx gh-pages -d dist -b gh-pages"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,vue,js,css,md}": ["eslint --fix", "prettier -w"]
+  },
+  "dependencies": {
+    "idb": "^7.1.1",
+    "lz-string": "^1.5.0",
+    "phaser": "^3.80.0",
+    "pinia": "^2.1.7",
+    "vue": "^3.5.0",
+    "vue-i18n": "^9.9.0",
+    "vue-router": "^4.3.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "@vitejs/plugin-vue": "^5.0.0",
+    "@vitest/coverage-v8": "^2.0.0",
+    "@vue/test-utils": "^2.4.3",
+    "autoprefixer": "^10.4.0",
+    "cross-env": "^7.0.3",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-vue": "^9.18.1",
+    "husky": "^9.0.0",
+    "jsdom": "^24.0.0",
+    "lint-staged": "^15.2.0",
+    "playwright": "^1.47.0",
+    "postcss": "^8.4.0",
+    "prettier": "^3.2.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0",
+    "vite-plugin-pwa": "^0.16.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/assets/svg/bullet.svg
+++ b/public/assets/svg/bullet.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="6" height="6" viewBox="0 0 6 6">
+  <circle cx="3" cy="3" r="2.5" fill="#ffffff" stroke="#d9d9d9" stroke-width="0.5"/>
+</svg>

--- a/public/assets/svg/coin.svg
+++ b/public/assets/svg/coin.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <circle cx="10" cy="10" r="9" fill="#ffd700" stroke="#b8860b" stroke-width="2"/>
+</svg>

--- a/public/assets/svg/enemy_grunt.svg
+++ b/public/assets/svg/enemy_grunt.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <rect x="3" y="3" width="18" height="18" rx="4" fill="#ff6b6b" stroke="#9c1b1b" stroke-width="2"/>
+  <rect x="6" y="9" width="12" height="3" fill="#9c1b1b"/>
+  <rect x="6" y="13" width="12" height="3" fill="#9c1b1b"/>
+</svg>

--- a/public/assets/svg/enemy_shooter.svg
+++ b/public/assets/svg/enemy_shooter.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <rect x="2" y="6" width="20" height="12" rx="3" fill="#ffa94d" stroke="#a85f13" stroke-width="2"/>
+  <circle cx="8" cy="12" r="2" fill="#2b2b2b"/>
+  <rect x="13" y="11" width="7" height="2" rx="1" fill="#2b2b2b"/>
+</svg>

--- a/public/assets/svg/pickup_gold.svg
+++ b/public/assets/svg/pickup_gold.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
+  <polygon points="9,1 17,9 9,17 1,9" fill="#ffd43b" stroke="#b68900" stroke-width="2"/>
+</svg>

--- a/public/assets/svg/player.svg
+++ b/public/assets/svg/player.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <defs>
+    <radialGradient id="g" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#9ee7ff"/>
+      <stop offset="100%" stop-color="#3aaef0"/>
+    </radialGradient>
+  </defs>
+  <circle cx="12" cy="12" r="10" fill="url(#g)" stroke="#0b6cbf" stroke-width="2"/>
+</svg>

--- a/public/assets/svg/red_dot.svg
+++ b/public/assets/svg/red_dot.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <circle cx="10" cy="10" r="9" fill="#ff3333"/>
+</svg>

--- a/public/assets/svg/task_button.svg
+++ b/public/assets/svg/task_button.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect x="2" y="2" width="60" height="60" rx="12" fill="#2d3748" stroke="#cbd5e1" stroke-width="4"/>
+  <path d="M32 16v32M16 32h32" stroke="#cbd5e1" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/public/assets/svg/tile_dark.svg
+++ b/public/assets/svg/tile_dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <rect width="64" height="64" fill="#0c0c0c"/>
+  <path d="M0 32h64M32 0v64" stroke="#151515" stroke-width="1"/>
+  <path d="M0 16h64M0 48h64M16 0v64M48 0v64" stroke="#111" stroke-width="1"/>
+</svg>

--- a/public/assets/svg/ui_aim_reticle.svg
+++ b/public/assets/svg/ui_aim_reticle.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <circle cx="10" cy="10" r="8" fill="none" stroke="#a0aec0" stroke-width="1.5"/>
+  <line x1="10" y1="1" x2="10" y2="5" stroke="#a0aec0" stroke-width="1.5"/>
+  <line x1="10" y1="15" x2="10" y2="19" stroke="#a0aec0" stroke-width="1.5"/>
+  <line x1="1" y1="10" x2="5" y2="10" stroke="#a0aec0" stroke-width="1.5"/>
+  <line x1="15" y1="10" x2="19" y2="10" stroke="#a0aec0" stroke-width="1.5"/>
+</svg>

--- a/public/assets/svg/ui_dash_icon.svg
+++ b/public/assets/svg/ui_dash_icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+  <path d="M3 10h9" stroke="#5b8cff" stroke-width="3" stroke-linecap="round"/>
+  <path d="M12 10l5-3v6z" fill="#5b8cff"/>
+</svg>

--- a/public/data/affixes.json
+++ b/public/data/affixes.json
@@ -1,0 +1,5 @@
+[
+  {"id":"affix_fast_enemies","desc":"敌人移速 +15%","effects":[{"stat":"enemy_speed_pct","value":0.15}]},
+  {"id":"affix_heavy_bullets","desc":"子弹伤害 +10%","effects":[{"stat":"bullet_damage_pct","value":0.1}]},
+  {"id":"affix_thick_skin","desc":"敌人受伤 -8%","effects":[{"stat":"enemy_damage_taken_pct","value":-0.08}]}
+]

--- a/public/data/drops.json
+++ b/public/data/drops.json
@@ -1,0 +1,5 @@
+{
+  "dt_common": [ {"item":"gold","min":5,"max":12,"weight":60}, {"item":"material_iron","min":1,"max":2,"weight":35}, {"item":"chip_box_N","min":1,"max":1,"weight":5} ],
+  "dt_elite":  [ {"item":"gold","min":20,"max":40,"weight":45}, {"item":"chip_box_R","min":1,"max":1,"weight":35}, {"item":"blueprint_rifle","min":1,"max":1,"weight":5} ],
+  "dt_boss":   [ {"item":"gold","min":80,"max":140,"weight":40}, {"item":"chip_box_SR","min":1,"max":1,"weight":20}, {"item":"blueprint_shotgun","min":1,"max":1,"weight":8} ]
+}

--- a/public/data/enemies.json
+++ b/public/data/enemies.json
@@ -1,0 +1,10 @@
+[
+  { "id":"grunt","hp":30,"atk":5,"speed":90,"ai":"chase","dropTableId":"dt_common" },
+  { "id":"shooter","hp":40,"atk":7,"speed":70,"ai":"kite_shoot","range":320,"rof":0.8,"dropTableId":"dt_common" },
+  { "id":"brute","hp":180,"atk":16,"speed":50,"ai":"charge","chargeCd":6,"dropTableId":"dt_common" },
+  { "id":"boomer","hp":35,"atk":22,"speed":80,"ai":"suicide","explodeRadius":120,"dropTableId":"dt_common" },
+  { "id":"summoner","hp":120,"atk":0,"speed":60,"ai":"summon","spawn":"grunt","spawnCount":3,"spawnCd":8,"dropTableId":"dt_elite" },
+  { "id":"mini_boss","hp":480,"atk":22,"speed":60,"ai":"phase_boss","phases":[{"hpPct":0.7,"skill":"dash"},{"hpPct":0.4,"skill":"spawn_minions"}],"dropTableId":"dt_elite" },
+  { "id":"boss_centipede","hp":2400,"atk":28,"speed":65,"ai":"raid_boss","skills":["line_laser","circle_bullets","tail_whip"],"dropTableId":"dt_boss" },
+  { "id":"boss_overseer","hp":3000,"atk":32,"speed":50,"ai":"raid_boss","skills":["summon","cone_blast","beam_track"],"dropTableId":"dt_boss" }
+]

--- a/public/data/index.json
+++ b/public/data/index.json
@@ -1,0 +1,1 @@
+{ "version": "1.0.0", "tables": { "levels": "levels.json", "enemies": "enemies.json", "weapons": "weapons.json", "drops": "drops.json", "progression": "progression.json", "affixes": "affixes.json", "skilltree": "skilltree.json", "quests": "quests.json" } }

--- a/public/data/levels.json
+++ b/public/data/levels.json
@@ -1,0 +1,26 @@
+[
+  { "id": "lv_1_1", "name": "废墟外围 A", "tileset": "ruins_A", "mode": "survival", "duration": 180, "waves": [
+      { "time": 0,   "spawns": [{"enemyId":"grunt","count":6}] },
+      { "time": 25,  "spawns": [{"enemyId":"shooter","count":4}] },
+      { "time": 60,  "spawns": [{"enemyId":"grunt","count":10},{"enemyId":"boomer","count":2}] },
+      { "time": 120, "spawns": [{"enemyId":"mini_boss","count":1}] }
+    ], "modifiers": ["affix_fast_enemies"], "rewards": {"gold": 60}, "difficultyScale": 1.0 },
+  { "id": "lv_1_2", "name": "废墟外围 B", "tileset": "ruins_A", "mode": "survival", "duration": 210, "waves": [
+      { "time": 0,   "spawns": [{"enemyId":"grunt","count":8}] },
+      { "time": 35,  "spawns": [{"enemyId":"shooter","count":6}] },
+      { "time": 90,  "spawns": [{"enemyId":"brute","count":2}] },
+      { "time": 150, "spawns": [{"enemyId":"mini_boss","count":1}] }
+    ], "rewards": {"gold": 80}, "difficultyScale": 1.2 },
+  { "id": "lv_1_boss", "name": "破碎广场", "mode": "survival", "duration": 240, "waves": [
+      { "time": 0, "spawns": [{"enemyId":"boss_centipede","count":1}] }
+    ], "rewards": {"gold": 150, "materials": {"iron": 4}}, "difficultyScale": 1.5 },
+  { "id": "lv_2_1", "name": "走廊 I", "mode": "survival", "duration": 210, "waves": [
+      { "time": 0, "spawns": [{"enemyId":"grunt","count":10}] },
+      { "time": 45, "spawns": [{"enemyId":"summoner","count":1}] },
+      { "time": 120, "spawns": [{"enemyId":"boomer","count":4}] },
+      { "time": 160, "spawns": [{"enemyId":"mini_boss","count":1}] }
+    ], "rewards": {"gold": 90}, "difficultyScale": 1.6 },
+  { "id": "lv_2_boss", "name": "试验深处", "mode": "survival", "duration": 240, "waves": [
+      { "time": 0, "spawns": [{"enemyId":"boss_overseer","count":1}] }
+    ], "rewards": {"gold": 200, "materials": {"crystal": 2}}, "difficultyScale": 2.0 }
+]

--- a/public/data/progression.json
+++ b/public/data/progression.json
@@ -1,0 +1,3 @@
+{ "playerLevelExp": [0, 20, 60, 120, 200, 300, 420, 560, 720, 900, 1100],
+  "upgradeCosts": { "weapon": [ {"level":1,"gold":40}, {"level":2,"gold":90}, {"level":3,"gold":180}, {"level":4,"gold":300} ],
+                     "armor":  [ {"level":1,"gold":30}, {"level":2,"gold":70}, {"level":3,"gold":150}, {"level":4,"gold":260} ] } }

--- a/public/data/quests.json
+++ b/public/data/quests.json
@@ -1,0 +1,10 @@
+{ "daily": [
+    {"id":"d_win2","desc":"通关任意关卡 2 次","goal":2,"reward":{"gold":60}},
+    {"id":"d_kill150","desc":"累计击杀 150 敌人","goal":150,"reward":{"gold":80}},
+    {"id":"d_weapon_family","desc":"使用同一武器家族通关 1 次","goal":1,"reward":{"crystal":1}}
+  ],
+  "weekly": [
+    {"id":"w_clear20","desc":"本周通关 20 次","goal":20,"reward":{"chip_box_R":1}},
+    {"id":"w_nodamage","desc":"完成 3 次无伤小关","goal":3,"reward":{"gold":300}}
+  ]
+}

--- a/public/data/skilltree.json
+++ b/public/data/skilltree.json
@@ -1,0 +1,10 @@
+{ "nodes": [
+  {"id":"hp1","name":"基础生命","cost":1,"effects":[{"stat":"hp","value":20}]},
+  {"id":"atk1","name":"基础攻击","cost":1,"effects":[{"stat":"atk","value":2}]},
+  {"id":"ms1","name":"基础移速","cost":1,"effects":[{"stat":"ms","value":0.05}]},
+  {"id":"crit1","name":"精准训练","cost":2,"effects":[{"stat":"critRate","value":0.05}]},
+  {"id":"dash1","name":"强化冲刺","cost":2,"effects":[{"stat":"cdr","value":0.05}]}
+],
+  "edges": [
+  {"from":"hp1","to":"crit1"}, {"from":"atk1","to":"crit1"}, {"from":"ms1","to":"dash1"}
+] }

--- a/public/data/weapons.json
+++ b/public/data/weapons.json
@@ -1,0 +1,6 @@
+[
+  { "id":"wp_pistol","name":"标准手枪","family":"pistol","baseAtk":8,"rof":4,"bulletSpeed":520,"spread":1,"maxLevel":10,"passives":[{"tier":3,"id":"stable"},{"tier":6,"id":"weakspot"}] },
+  { "id":"wp_rifle","name":"突击步枪","family":"rifle","baseAtk":6,"rof":9,"bulletSpeed":600,"spread":2,"maxLevel":10,"passives":[{"tier":3,"id":"stabilizer"},{"tier":6,"id":"suppress"}] },
+  { "id":"wp_shotgun","name":"霰弹枪","family":"shotgun","baseAtk":14,"rof":1.2,"pellets":6,"bulletSpeed":520,"spread":12,"maxLevel":10,"passives":[{"tier":3,"id":"wide_blast"},{"tier":6,"id":"bleed"}] },
+  { "id":"wp_beam","name":"相位射线","family":"beam","baseAtk":4,"rof":12,"pierce":2,"bulletSpeed":900,"spread":0,"maxLevel":10,"passives":[{"tier":3,"id":"pierce+1"},{"tier":6,"id":"overheat"}] }
+]

--- a/public/quests/daily.json
+++ b/public/quests/daily.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "reset": "daily",
+  "tasks": [
+    { "id": "daily_play_1", "title": "游玩 1 局", "progressRequired": 1 },
+    { "id": "daily_kill_10", "title": "击杀 10 敌人", "progressRequired": 10 },
+    { "id": "daily_collect_20", "title": "拾取 20 金币", "progressRequired": 20 }
+  ]
+}

--- a/public/quests/weekly.json
+++ b/public/quests/weekly.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "reset": "weekly",
+  "tasks": [
+    { "id": "weekly_kill_100", "title": "击杀 100 敌人", "progressRequired": 100 },
+    { "id": "weekly_collect_200", "title": "拾取 200 金币", "progressRequired": 200 }
+  ]
+}

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,0 +1,16 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import { createRouter, createWebHashHistory } from 'vue-router';
+import App from '@/ui/App.vue';
+import '@/styles/tailwind.css';
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    { path: '/', component: () => import('@/ui/pages/Home.vue') },
+    { path: '/battle', component: () => import('@/ui/pages/Battle.vue') },
+    { path: '/quests', component: () => import('@/ui/pages/Quests.vue') },
+  ],
+});
+
+createApp(App).use(createPinia()).use(router).mount('#app');

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const LevelWave = z.object({
+  time: z.number().nonnegative(),
+  spawns: z.array(
+    z.object({ enemyId: z.string(), count: z.number().int().positive() })
+  )
+});
+export const LevelCfg = z.object({
+  id: z.string(),
+  name: z.string(),
+  waves: z.array(LevelWave),
+  difficultyScale: z.number().positive().default(1)
+});
+export type LevelCfg = z.infer<typeof LevelCfg>;
+
+export class ConfigService {
+  private cache = new Map<string, unknown>();
+  async loadJson<T>(url: string, schema: z.ZodType<T>): Promise<T> {
+    const res = await fetch(url);
+    const json = await res.json();
+    const parsed = schema.parse(json);
+    this.cache.set(url, parsed);
+    return parsed;
+  }
+}
+
+export const configService = new ConfigService();

--- a/src/core/quests/quests.service.ts
+++ b/src/core/quests/quests.service.ts
@@ -1,0 +1,57 @@
+import { configService } from '@/core/config/config.service';
+import { saveService } from '@/core/save/save.service';
+
+export interface QuestDef { id:string; desc:string; goal:number; reward: Record<string, number> }
+export interface QuestsDef { daily: QuestDef[]; weekly?: QuestDef[] }
+export interface DailyProgress { dateKey: string; counters: Record<string, number>; claimed: string[] }
+
+export const dateKeyToday = () => {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, '0');
+  const d = String(now.getDate()).padStart(2, '0');
+  return `${y}${m}${d}`;
+};
+
+const SLOT_ID = 'slot1';
+const KEY = 'daily_progress';
+
+export class QuestsService {
+  async loadDefs(): Promise<QuestsDef> {
+    return configService.loadJson<QuestsDef>('/data/quests.json', (x: any) => x);
+  }
+  async loadProgress(): Promise<DailyProgress> {
+    const save = (await saveService.get<any>(SLOT_ID)) ?? { inventory: { gold: 0, items: [] } };
+    const dp: DailyProgress =
+      save[KEY] ?? { dateKey: dateKeyToday(), counters: {}, claimed: [] };
+    if (dp.dateKey !== dateKeyToday()) {
+      dp.dateKey = dateKeyToday();
+      dp.counters = {};
+      dp.claimed = [];
+      save[KEY] = dp;
+      await saveService.put(SLOT_ID, save);
+    }
+    return dp;
+  }
+  async saveProgress(p: DailyProgress) {
+    const save = (await saveService.get<any>(SLOT_ID)) ?? { inventory: { gold: 0, items: [] } };
+    save[KEY] = p;
+    await saveService.put(SLOT_ID, save);
+  }
+  async grantReward(reward: Record<string, number>) {
+    const save = (await saveService.get<any>(SLOT_ID)) ?? { inventory: { gold: 0, items: [] } };
+    save.inventory.gold = (save.inventory.gold ?? 0) + (reward.gold ?? 0);
+    if (reward.crystal)
+      save.inventory.crystal = (save.inventory.crystal ?? 0) + reward.crystal;
+    for (const [k, v] of Object.entries(reward)) {
+      if (k === 'gold' || k === 'crystal') continue;
+      const items = save.inventory.items ?? (save.inventory.items = []);
+      const idx = items.findIndex((it: any) => it.id === k);
+      if (idx >= 0) items[idx].count += v;
+      else items.push({ id: k, count: v });
+    }
+    await saveService.put(SLOT_ID, save);
+  }
+}
+
+export const questsService = new QuestsService();

--- a/src/core/save/save.service.ts
+++ b/src/core/save/save.service.ts
@@ -1,0 +1,38 @@
+import { openDB } from 'idb';
+import { compressToUTF16, decompressFromUTF16 } from 'lz-string';
+
+export interface SaveSlot {
+  meta: { schemaVersion: number; updatedAt: number };
+  data: unknown;
+}
+
+const DB_NAME = 'game_saves';
+const STORE = 'profiles';
+
+export class SaveService {
+  private dbPromise = openDB(DB_NAME, 1, {
+    upgrade(db) {
+      db.createObjectStore(STORE);
+    }
+  });
+
+  async put(id: string, data: unknown) {
+    const db = await this.dbPromise;
+    const payload: SaveSlot = {
+      meta: { schemaVersion: 1, updatedAt: Date.now() },
+      data
+    };
+    const str = compressToUTF16(JSON.stringify(payload));
+    await db.put(STORE, str, id);
+  }
+
+  async get<T = unknown>(id: string): Promise<T | null> {
+    const db = await this.dbPromise;
+    const raw = await db.get(STORE, id);
+    if (!raw) return null;
+    const json = JSON.parse(decompressFromUTF16(raw as string));
+    return json.data as T;
+  }
+}
+
+export const saveService = new SaveService();

--- a/src/data/affixes.json
+++ b/src/data/affixes.json
@@ -1,0 +1,5 @@
+[
+  {"id":"affix_fast_enemies","desc":"敌人移速 +15%","effects":[{"stat":"enemy_speed_pct","value":0.15}]},
+  {"id":"affix_heavy_bullets","desc":"子弹伤害 +10%","effects":[{"stat":"bullet_damage_pct","value":0.1}]},
+  {"id":"affix_thick_skin","desc":"敌人受伤 -8%","effects":[{"stat":"enemy_damage_taken_pct","value":-0.08}]}
+]

--- a/src/data/drops.json
+++ b/src/data/drops.json
@@ -1,0 +1,5 @@
+{
+  "dt_common": [ {"item":"gold","min":5,"max":12,"weight":60}, {"item":"material_iron","min":1,"max":2,"weight":35}, {"item":"chip_box_N","min":1,"max":1,"weight":5} ],
+  "dt_elite":  [ {"item":"gold","min":20,"max":40,"weight":45}, {"item":"chip_box_R","min":1,"max":1,"weight":35}, {"item":"blueprint_rifle","min":1,"max":1,"weight":5} ],
+  "dt_boss":   [ {"item":"gold","min":80,"max":140,"weight":40}, {"item":"chip_box_SR","min":1,"max":1,"weight":20}, {"item":"blueprint_shotgun","min":1,"max":1,"weight":8} ]
+}

--- a/src/data/enemies.json
+++ b/src/data/enemies.json
@@ -1,0 +1,10 @@
+[
+  { "id":"grunt","hp":30,"atk":5,"speed":90,"ai":"chase","dropTableId":"dt_common" },
+  { "id":"shooter","hp":40,"atk":7,"speed":70,"ai":"kite_shoot","range":320,"rof":0.8,"dropTableId":"dt_common" },
+  { "id":"brute","hp":180,"atk":16,"speed":50,"ai":"charge","chargeCd":6,"dropTableId":"dt_common" },
+  { "id":"boomer","hp":35,"atk":22,"speed":80,"ai":"suicide","explodeRadius":120,"dropTableId":"dt_common" },
+  { "id":"summoner","hp":120,"atk":0,"speed":60,"ai":"summon","spawn":"grunt","spawnCount":3,"spawnCd":8,"dropTableId":"dt_elite" },
+  { "id":"mini_boss","hp":480,"atk":22,"speed":60,"ai":"phase_boss","phases":[{"hpPct":0.7,"skill":"dash"},{"hpPct":0.4,"skill":"spawn_minions"}],"dropTableId":"dt_elite" },
+  { "id":"boss_centipede","hp":2400,"atk":28,"speed":65,"ai":"raid_boss","skills":["line_laser","circle_bullets","tail_whip"],"dropTableId":"dt_boss" },
+  { "id":"boss_overseer","hp":3000,"atk":32,"speed":50,"ai":"raid_boss","skills":["summon","cone_blast","beam_track"],"dropTableId":"dt_boss" }
+]

--- a/src/data/index.json
+++ b/src/data/index.json
@@ -1,0 +1,1 @@
+{ "version": "1.0.0", "tables": { "levels": "levels.json", "enemies": "enemies.json", "weapons": "weapons.json", "drops": "drops.json", "progression": "progression.json", "affixes": "affixes.json", "skilltree": "skilltree.json", "quests": "quests.json" } }

--- a/src/data/levels.json
+++ b/src/data/levels.json
@@ -1,0 +1,26 @@
+[
+  { "id": "lv_1_1", "name": "废墟外围 A", "tileset": "ruins_A", "mode": "survival", "duration": 180, "waves": [
+      { "time": 0,   "spawns": [{"enemyId":"grunt","count":6}] },
+      { "time": 25,  "spawns": [{"enemyId":"shooter","count":4}] },
+      { "time": 60,  "spawns": [{"enemyId":"grunt","count":10},{"enemyId":"boomer","count":2}] },
+      { "time": 120, "spawns": [{"enemyId":"mini_boss","count":1}] }
+    ], "modifiers": ["affix_fast_enemies"], "rewards": {"gold": 60}, "difficultyScale": 1.0 },
+  { "id": "lv_1_2", "name": "废墟外围 B", "tileset": "ruins_A", "mode": "survival", "duration": 210, "waves": [
+      { "time": 0,   "spawns": [{"enemyId":"grunt","count":8}] },
+      { "time": 35,  "spawns": [{"enemyId":"shooter","count":6}] },
+      { "time": 90,  "spawns": [{"enemyId":"brute","count":2}] },
+      { "time": 150, "spawns": [{"enemyId":"mini_boss","count":1}] }
+    ], "rewards": {"gold": 80}, "difficultyScale": 1.2 },
+  { "id": "lv_1_boss", "name": "破碎广场", "mode": "survival", "duration": 240, "waves": [
+      { "time": 0, "spawns": [{"enemyId":"boss_centipede","count":1}] }
+    ], "rewards": {"gold": 150, "materials": {"iron": 4}}, "difficultyScale": 1.5 },
+  { "id": "lv_2_1", "name": "走廊 I", "mode": "survival", "duration": 210, "waves": [
+      { "time": 0, "spawns": [{"enemyId":"grunt","count":10}] },
+      { "time": 45, "spawns": [{"enemyId":"summoner","count":1}] },
+      { "time": 120, "spawns": [{"enemyId":"boomer","count":4}] },
+      { "time": 160, "spawns": [{"enemyId":"mini_boss","count":1}] }
+    ], "rewards": {"gold": 90}, "difficultyScale": 1.6 },
+  { "id": "lv_2_boss", "name": "试验深处", "mode": "survival", "duration": 240, "waves": [
+      { "time": 0, "spawns": [{"enemyId":"boss_overseer","count":1}] }
+    ], "rewards": {"gold": 200, "materials": {"crystal": 2}}, "difficultyScale": 2.0 }
+]

--- a/src/data/progression.json
+++ b/src/data/progression.json
@@ -1,0 +1,3 @@
+{ "playerLevelExp": [0, 20, 60, 120, 200, 300, 420, 560, 720, 900, 1100],
+  "upgradeCosts": { "weapon": [ {"level":1,"gold":40}, {"level":2,"gold":90}, {"level":3,"gold":180}, {"level":4,"gold":300} ],
+                     "armor":  [ {"level":1,"gold":30}, {"level":2,"gold":70}, {"level":3,"gold":150}, {"level":4,"gold":260} ] } }

--- a/src/data/quests.json
+++ b/src/data/quests.json
@@ -1,0 +1,10 @@
+{ "daily": [
+    {"id":"d_win2","desc":"通关任意关卡 2 次","goal":2,"reward":{"gold":60}},
+    {"id":"d_kill150","desc":"累计击杀 150 敌人","goal":150,"reward":{"gold":80}},
+    {"id":"d_weapon_family","desc":"使用同一武器家族通关 1 次","goal":1,"reward":{"crystal":1}}
+  ],
+  "weekly": [
+    {"id":"w_clear20","desc":"本周通关 20 次","goal":20,"reward":{"chip_box_R":1}},
+    {"id":"w_nodamage","desc":"完成 3 次无伤小关","goal":3,"reward":{"gold":300}}
+  ]
+}

--- a/src/data/skilltree.json
+++ b/src/data/skilltree.json
@@ -1,0 +1,10 @@
+{ "nodes": [
+  {"id":"hp1","name":"基础生命","cost":1,"effects":[{"stat":"hp","value":20}]},
+  {"id":"atk1","name":"基础攻击","cost":1,"effects":[{"stat":"atk","value":2}]},
+  {"id":"ms1","name":"基础移速","cost":1,"effects":[{"stat":"ms","value":0.05}]},
+  {"id":"crit1","name":"精准训练","cost":2,"effects":[{"stat":"critRate","value":0.05}]},
+  {"id":"dash1","name":"强化冲刺","cost":2,"effects":[{"stat":"cdr","value":0.05}]}
+],
+  "edges": [
+  {"from":"hp1","to":"crit1"}, {"from":"atk1","to":"crit1"}, {"from":"ms1","to":"dash1"}
+] }

--- a/src/data/weapons.json
+++ b/src/data/weapons.json
@@ -1,0 +1,6 @@
+[
+  { "id":"wp_pistol","name":"标准手枪","family":"pistol","baseAtk":8,"rof":4,"bulletSpeed":520,"spread":1,"maxLevel":10,"passives":[{"tier":3,"id":"stable"},{"tier":6,"id":"weakspot"}] },
+  { "id":"wp_rifle","name":"突击步枪","family":"rifle","baseAtk":6,"rof":9,"bulletSpeed":600,"spread":2,"maxLevel":10,"passives":[{"tier":3,"id":"stabilizer"},{"tier":6,"id":"suppress"}] },
+  { "id":"wp_shotgun","name":"霰弹枪","family":"shotgun","baseAtk":14,"rof":1.2,"pellets":6,"bulletSpeed":520,"spread":12,"maxLevel":10,"passives":[{"tier":3,"id":"wide_blast"},{"tier":6,"id":"bleed"}] },
+  { "id":"wp_beam","name":"相位射线","family":"beam","baseAtk":4,"rof":12,"pierce":2,"bulletSpeed":900,"spread":0,"maxLevel":10,"passives":[{"tier":3,"id":"pierce+1"},{"tier":6,"id":"overheat"}] }
+]

--- a/src/effects/RewardAnimation.ts
+++ b/src/effects/RewardAnimation.ts
@@ -1,0 +1,75 @@
+import Phaser from 'phaser';
+
+function ensureParticleTexture(scene: Phaser.Scene) {
+  const key = 'reward-dot';
+  if (scene.textures.exists(key)) return key;
+  const g = scene.add.graphics();
+  g.fillStyle(0xffffff, 1);
+  g.fillCircle(4, 4, 4);
+  g.generateTexture(key, 8, 8);
+  g.destroy();
+  return key;
+}
+
+export async function playRewardAnimation(
+  scene: Phaser.Scene,
+  fromX: number,
+  fromY: number,
+  toX: number,
+  toY: number,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const tex = ensureParticleTexture(scene);
+    const icon = scene.add.image(fromX, fromY, tex).setScale(3).setAlpha(0.95).setDepth(1000);
+    const emitter = scene.add.particles(0, 0, tex, {
+      x: fromX,
+      y: fromY,
+      speed: { min: 80, max: 180 },
+      angle: { min: 0, max: 360 },
+      scale: { start: 1, end: 0 },
+      lifespan: 500,
+      quantity: 20,
+      blendMode: 'ADD',
+    });
+
+    const ctrlX = (fromX + toX) / 2 + Phaser.Math.Between(-60, 60);
+    const ctrlY = Math.min(fromY, toY) - 120;
+
+    scene.tweens.add({
+      targets: icon,
+      x: {
+        getStart: () => fromX,
+        getEnd: () => toX,
+      },
+      y: {
+        getStart: () => fromY,
+        getEnd: () => toY,
+      },
+      ease: (t: number) => {
+        const x = Phaser.Math.Interpolation.QuadraticBezier(t, 0, 0.5, 1);
+        return x;
+      },
+      duration: 700,
+      onUpdate: (tw, _target: any) => {
+        const t = tw.progress;
+        const bx = (1 - t) * (1 - t) * fromX + 2 * (1 - t) * t * ctrlX + t * t * toX;
+        const by = (1 - t) * (1 - t) * fromY + 2 * (1 - t) * t * ctrlY + t * t * toY;
+        icon.setPosition(bx, by);
+      },
+      onComplete: () => {
+        emitter.explode(24, toX, toY);
+        const ring = scene.add.circle(toX, toY, 6, 0xffffff, 0.6).setDepth(1000);
+        scene.tweens.add({
+          targets: ring,
+          radius: 28,
+          alpha: 0,
+          duration: 380,
+          onComplete: () => ring.destroy(),
+        });
+        icon.destroy();
+        setTimeout(() => emitter.destroy(), 120);
+        resolve();
+      },
+    });
+  });
+}

--- a/src/game/prefabs/enemyFactory.ts
+++ b/src/game/prefabs/enemyFactory.ts
@@ -1,0 +1,23 @@
+import type Phaser from 'phaser';
+import type { EnemyCfg } from '@/types/battle';
+
+export type EnemyGO = Phaser.Physics.Arcade.Sprite & {
+  hp: number;
+  cfg: EnemyCfg;
+  aiTick?: (dt: number) => void;
+};
+
+export function createEnemy(
+  scene: Phaser.Scene,
+  cfg: EnemyCfg,
+  x: number,
+  y: number,
+): EnemyGO {
+  const key = cfg.id.includes('shooter') ? 'enemy_shooter' : 'enemy_grunt';
+  const e = scene.physics.add.sprite(x, y, key) as EnemyGO;
+  e.setCircle(10);
+  e.setCollideWorldBounds(true);
+  e.hp = cfg.hp;
+  e.cfg = cfg;
+  return e;
+}

--- a/src/game/scenes/BootScene.ts
+++ b/src/game/scenes/BootScene.ts
@@ -1,0 +1,35 @@
+import Phaser from 'phaser';
+import { GameScene } from './GameScene';
+
+export class BootScene extends Phaser.Scene {
+  private started = false;
+
+  constructor() {
+    super('BootScene');
+  }
+
+  create() {
+    const { width, height } = this.scale;
+    this.add
+      .text(width / 2, height / 2, '点击/按任意键开始', {
+        fontFamily: 'sans-serif',
+        fontSize: '24px',
+        color: '#ffffff',
+      })
+      .setOrigin(0.5);
+
+    const start = async () => {
+      if (this.started) return;
+      this.started = true;
+      try {
+        await this.sound?.context?.resume();
+      } catch {
+        // ignore
+      }
+      this.scene.start(GameScene.name);
+    };
+
+    this.input.keyboard?.on('keydown', start);
+    this.input.once('pointerdown', start);
+  }
+}

--- a/src/game/scenes/GameScene.ts
+++ b/src/game/scenes/GameScene.ts
@@ -1,0 +1,242 @@
+import Phaser from 'phaser';
+import { configService } from '@/core/config/config.service';
+import type { LevelCfg, EnemyCfg, DropTable } from '@/types/battle';
+import { Spawner } from '@/game/systems/spawner';
+import { createEnemy, type EnemyGO } from '@/game/prefabs/enemyFactory';
+import { makeChase } from '@/game/systems/ai/chase';
+import { makeKiteShoot } from '@/game/systems/ai/kite_shoot';
+import { useBattleStore } from '@/stores/battle';
+import { MissionManager } from '@/managers/MissionManager';
+import { MissionButton } from '@/ui/MissionButton';
+import { MissionPanel } from '@/ui/MissionPanel';
+import type { MissionDef } from '@/types/mission';
+
+const WEEKLY_DEFS: MissionDef[] = [
+  {
+    id: 'w1',
+    title: 'Eliminate 50 enemies',
+    desc: 'Any mode. Rack up eliminations.',
+    target: 50,
+    condition: { type: 'KILL' },
+    reward: { coins: 500 },
+  },
+  {
+    id: 'w2',
+    title: 'Win 10 matches',
+    desc: 'Victory tastes sweet.',
+    target: 10,
+    condition: { type: 'WINS' },
+    reward: { gems: 20 },
+  },
+  {
+    id: 'w3',
+    title: 'AR Specialist',
+    desc: 'Get 30 AR eliminations',
+    target: 30,
+    condition: { type: 'WEAPON_KILL', weaponId: 'AR' },
+    reward: { itemId: 'AR_Core', amount: 3 },
+  },
+];
+
+export class GameScene extends Phaser.Scene {
+  private player!: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody;
+  private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+  private bullets!: Phaser.Physics.Arcade.Group;
+  private enemies!: Phaser.Physics.Arcade.Group;
+  private drops!: Phaser.Physics.Arcade.Group;
+
+  private level!: LevelCfg;
+  private enemyCfgs!: Record<string, EnemyCfg>;
+  private dropTables!: DropTable;
+  private spawner!: Spawner;
+  private missions!: MissionManager;
+  private missionBtn!: MissionButton;
+  private missionPanel!: MissionPanel;
+  private debugEnemy?: Phaser.GameObjects.Rectangle;
+
+  constructor() {
+    super('GameScene');
+  }
+
+  preload() {
+    this.load.svg('player', '/assets/svg/player.svg');
+    this.load.svg('enemy_grunt', '/assets/svg/enemy_grunt.svg');
+    this.load.svg('enemy_shooter', '/assets/svg/enemy_shooter.svg');
+    this.load.svg('bullet', '/assets/svg/bullet.svg');
+    this.load.svg('pickup_gold', '/assets/svg/pickup_gold.svg');
+    this.load.svg('tile_dark', '/assets/svg/tile_dark.svg');
+  }
+
+  async create() {
+    const battle = useBattleStore();
+    battle.start(battle.levelId);
+    this.missions = new MissionManager(WEEKLY_DEFS);
+    this.missions.ensureWeek();
+
+    const { width, height } = this.scale;
+    const bg = this.add.tileSprite(0, 0, width * 4, height * 4, 'tile_dark').setOrigin(0);
+    this.physics.world.setBounds(0, 0, bg.width, bg.height);
+
+    const [levels] = await Promise.all([
+      configService.loadJson<LevelCfg[]>('/data/levels.json', (x: any) => x),
+    ]);
+    this.level = levels.find((l) => l.id === battle.levelId)!;
+
+    const enemies = await configService.loadJson<any[]>('/data/enemies.json', (x: any) => x);
+    this.enemyCfgs = Object.fromEntries(enemies.map((e) => [e.id, e]));
+    this.dropTables = await configService.loadJson<DropTable>(
+      '/data/drops.json',
+      (x: any) => x,
+    );
+
+    this.player = this.physics.add
+      .sprite(400, 300, 'player')
+      .setCircle(10)
+      .setCollideWorldBounds(true);
+
+    this.cursors = this.input.keyboard!.createCursorKeys();
+    this.cameras.main.startFollow(this.player, true, 0.1, 0.1);
+    this.cameras.main.setBounds(0, 0, bg.width, bg.height);
+
+    this.bullets = this.physics.add.group({ maxSize: 200 });
+    this.enemies = this.physics.add.group({ maxSize: 100 });
+    this.drops = this.physics.add.group({ maxSize: 100 });
+
+    this.spawner = new Spawner(this.level, (enemyId) => this.spawnEnemy(enemyId));
+
+    // Mission UI
+    const cam = this.cameras.main;
+    const btnX = cam.worldView.x + cam.width - 100;
+    const btnY = cam.worldView.y + 40;
+    this.missionBtn = new MissionButton(this, btnX, btnY);
+    this.add.existing(this.missionBtn);
+    this.missionBtn.setInteractive({ useHandCursor: true }).on('pointerup', () => {
+      if (!this.missionPanel.visible) this.missionPanel.setVisible(true);
+    });
+    this.missionPanel = new MissionPanel(this, cam.centerX, cam.centerY, this.missions);
+    this.add.existing(this.missionPanel);
+
+    // Demo enemy rectangle for camera-bound movement
+    this.debugEnemy = this.add.rectangle(200, 200, 32, 32, 0x5eead4).setOrigin(0.5);
+
+    this.physics.add.overlap(this.bullets, this.enemies, (_b, _e) => {
+      const b = _b as Phaser.Physics.Arcade.Sprite;
+      const e = _e as EnemyGO;
+      if ((b as any).hostile) return;
+      b.destroy();
+      this.hurtEnemy(e, 20);
+    });
+
+    this.physics.add.overlap(this.bullets, this.player, (_b) => {
+      const b = _b as any;
+      if (!b.hostile) return;
+      b.destroy();
+      // TODO: player damage handling
+    });
+
+    this.physics.add.overlap(this.drops, this.player, (_d) => {
+      _d.destroy();
+      battle.addGold(5);
+    });
+
+    this.input.on('pointerdown', () => this.fire());
+
+    // debug keyboard shortcuts
+    this.input.keyboard?.on('keydown-K', () => this.missions.addProgress('KILL', 1));
+    this.input.keyboard?.on('keydown-V', () => this.missions.addProgress('WINS', 1));
+    this.input.keyboard?.on('keydown-A', () => this.missions.addProgress('WEAPON_KILL', 1, 'AR'));
+  }
+
+  update(_: number, dtMs: number) {
+    if (!this.player || !this.cursors) return;
+    const dt = dtMs / 1000;
+    const battle = useBattleStore();
+    battle.tick(dt);
+
+    const cam = this.cameras?.main;
+    const vw = cam?.worldView;
+    if (vw && this.debugEnemy) {
+      const leftX = vw.x;
+      const rightX = vw.x + vw.width;
+      const t = Math.sin(time / 600);
+      this.debugEnemy.x = Phaser.Math.Linear(leftX + 60, rightX - 60, (t + 1) / 2);
+    }
+
+    const speed = 220;
+    const vx = (this.cursors.left?.isDown ? -1 : 0) + (this.cursors.right?.isDown ? 1 : 0);
+    const vy = (this.cursors.up?.isDown ? -1 : 0) + (this.cursors.down?.isDown ? 1 : 0);
+    const len = Math.hypot(vx, vy) || 1;
+    this.player.setVelocity((vx / len) * speed, (vy / len) * speed);
+
+    this.spawner.update(dt);
+
+    (this.enemies.getChildren() as EnemyGO[]).forEach((e) => e.aiTick?.(dt));
+
+    if (this.level.mode === 'survival' && battle.elapsed >= this.level.duration) {
+      this.finish();
+    }
+  }
+
+  private fire() {
+    const p = this.input.activePointer;
+    const ang = Phaser.Math.Angle.Between(
+      this.player.x,
+      this.player.y,
+      p.worldX,
+      p.worldY,
+    );
+    const b = this.bullets.create(this.player.x, this.player.y, 'bullet') as Phaser.Physics.Arcade.Sprite;
+    b.setCircle(3).body.setAllowGravity(false);
+    const speed = 560;
+    b.setVelocity(Math.cos(ang) * speed, Math.sin(ang) * speed);
+    (b as any).hostile = false;
+    this.time.delayedCall(2000, () => b.destroy());
+  }
+
+  private spawnEnemy(enemyId: string) {
+    const cfg = this.enemyCfgs[enemyId];
+    if (!cfg) return;
+    const x = this.player.x + (Math.random() < 0.5 ? -1 : 1) * (300 + Math.random() * 200);
+    const y = this.player.y + (Math.random() < 0.5 ? -1 : 1) * (300 + Math.random() * 200);
+    const e = createEnemy(this, cfg, x, y);
+    if (cfg.ai === 'kite_shoot') makeKiteShoot(this, e, this.player);
+    else makeChase(e, this.player);
+    this.enemies.add(e);
+  }
+
+  private hurtEnemy(e: EnemyGO, dmg: number) {
+    e.hp -= dmg;
+    e.setTintFill(0xffffff);
+    this.time.delayedCall(50, () => e.clearTint());
+    if (e.hp <= 0) {
+      useBattleStore().addKill();
+      this.missions.addProgress('KILL', 1);
+      this.dropFrom(e.cfg.dropTableId ?? 'dt_common', e.x, e.y);
+      e.destroy();
+    }
+  }
+
+  private dropFrom(tableId: string, x: number, y: number) {
+    const table = this.dropTables[tableId];
+    if (!table) return;
+    const d = this.drops.create(x, y, 'pickup_gold') as Phaser.Physics.Arcade.Sprite;
+    d.setCircle(8);
+    d.body.setAllowGravity(false);
+    const mag = () => {
+      const dx = this.player.x - d.x;
+      const dy = this.player.y - d.y;
+      const dist = Math.hypot(dx, dy);
+      if (dist < 220) d.setVelocity((dx / dist) * 180, (dy / dist) * 180);
+    };
+    this.time.addEvent({ delay: 50, callback: mag, loop: true });
+    this.time.delayedCall(6000, () => d.destroy());
+  }
+
+  private finish() {
+    const battle = useBattleStore();
+    battle.end(battle.kills > 30 ? 'S' : battle.kills > 15 ? 'A' : 'B');
+    this.missions.addProgress('WINS', 1);
+    this.scene.pause();
+    this.scene.launch('ResultScene');
+  }
+}

--- a/src/game/scenes/ResultScene.ts
+++ b/src/game/scenes/ResultScene.ts
@@ -1,0 +1,44 @@
+import Phaser from 'phaser';
+import { useBattleStore } from '@/stores/battle';
+import { saveService } from '@/core/save/save.service';
+
+export class ResultScene extends Phaser.Scene {
+  constructor() {
+    super('ResultScene');
+  }
+
+  create() {
+    const b = useBattleStore();
+    const { width, height } = this.scale;
+    this.add
+      .rectangle(width / 2, height / 2, 420, 240, 0x000000, 0.7)
+      .setStrokeStyle(2, 0xffffff, 0.4);
+    this.add
+      .text(width / 2, height / 2 - 60, `评定 ${b.resultGrade}`, {
+        fontSize: '28px',
+        color: '#fff',
+      })
+      .setOrigin(0.5);
+    this.add
+      .text(width / 2, height / 2 - 10, `击杀 ${b.kills} | 金币 +${b.goldGained}`, {
+        fontSize: '18px',
+        color: '#fff',
+      })
+      .setOrigin(0.5);
+
+    const btn = this.add
+      .text(width / 2, height / 2 + 60, '回基地（保存）', {
+        fontSize: '20px',
+        color: '#5B8CFF',
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    btn.on('pointerdown', async () => {
+      const prev = (await saveService.get<any>('slot1')) ?? { inventory: { gold: 0 }, progress: {} };
+      prev.inventory.gold = (prev.inventory.gold ?? 0) + b.goldGained;
+      await saveService.put('slot1', prev);
+      window.location.hash = '#/';
+    });
+  }
+}

--- a/src/game/scenes/UIScene.ts
+++ b/src/game/scenes/UIScene.ts
@@ -1,0 +1,87 @@
+import Phaser from 'phaser';
+import { QuestManager } from '@/services/QuestManager';
+
+export default class UIScene extends Phaser.Scene {
+  private quests!: QuestManager;
+  private btn!: Phaser.GameObjects.Image;
+  private badge!: Phaser.GameObjects.Image;
+  private badgeText!: Phaser.GameObjects.Text;
+  private panel?: Phaser.GameObjects.Container;
+
+  constructor() { super({ key: 'UIScene' }); }
+
+  init(data: { quests: QuestManager }) { this.quests = data.quests; }
+
+  preload() {
+    this.load.svg('ui_task_btn', '/assets/svg/task_button.svg');
+    this.load.svg('ui_badge', '/assets/svg/red_dot.svg');
+    this.load.svg('coin', '/assets/svg/coin.svg');
+  }
+
+  create() {
+    const { width } = this.scale;
+    this.btn = this.add.image(width - 100, 50, 'ui_task_btn').setInteractive({ useHandCursor: true }).setDepth(1000);
+    this.btn.on('pointerup', () => this.togglePanel());
+
+    this.badge = this.add.image(this.btn.x + 24, this.btn.y - 22, 'ui_badge').setDepth(1001);
+    this.badgeText = this.add.text(this.badge.x, this.badge.y, '0', { fontSize: '14px', color: '#fff' }).setOrigin(0.5).setDepth(1002);
+    const refresh = () => {
+      const n = this.quests.badgeCount();
+      this.badge.setVisible(n > 0);
+      this.badgeText.setVisible(n > 0);
+      this.badgeText.setText(String(n));
+    };
+    this.quests.on('changed', refresh);
+    refresh();
+
+    this.createPanel();
+  }
+
+  private createPanel() {
+    const { width } = this.scale;
+    const panelW = 380;
+    const panelH = 300;
+    const bg = this.add.rectangle(0,0,panelW,panelH,0x000000,0.7).setOrigin(0);
+    const title = this.add.text(16,12,'任务',{ fontSize:'20px', color:'#fff' });
+    this.panel = this.add.container(width - panelW - 20,80,[bg,title]).setDepth(999).setVisible(false);
+
+    const render = (type:'daily'|'weekly', startY:number) => {
+      const header=this.add.text(16,startY,type==='daily'?'每日任务':'每周任务',{fontSize:'16px',color:'#9feaf9'});
+      this.panel!.add(header);
+      let y=startY+28;
+      for(const t of this.quests.getTasks(type)){
+        const text=this.add.text(16,y,`${t.title}  ${t.progress??0}/${t.progressRequired}`,{fontSize:'14px',color:'#fff'});
+        const btn=this.add.text(panelW-86,y,this.quests.canClaim(t.id)?'领取':'进行中',{fontSize:'14px',color:this.quests.canClaim(t.id)?'#00ff99':'#aaa'}).setInteractive({useHandCursor:true});
+        btn.on('pointerup',()=>{
+          if(this.quests.claim(t.id)){
+            text.setText(`${t.title}  ${t.progress??0}/${t.progressRequired}`);
+            btn.setText('已领取').setColor('#aaa');
+            this.playReward(btn.x,btn.y);
+          }
+        });
+        this.panel!.add([text,btn]);
+        y+=28;
+      }
+    };
+    render('daily',44);
+    render('weekly',44+28*(this.quests.getTasks('daily').length+1));
+  }
+
+  private togglePanel(){ if(this.panel) this.panel.visible=!this.panel.visible; }
+
+  private playReward(x:number,y:number){
+    for(let i=0;i<10;i++){
+      const c=this.add.image(x,y,'coin').setDepth(1200).setScale(0.6);
+      this.tweens.add({
+        targets:c,
+        x:this.btn.x+Phaser.Math.Between(-20,20),
+        y:this.btn.y+Phaser.Math.Between(-10,10),
+        alpha:0.2,
+        angle:Phaser.Math.Between(-180,180),
+        duration:Phaser.Math.Between(500,800),
+        ease:'Cubic.easeIn',
+        onComplete:()=>c.destroy()
+      });
+    }
+  }
+}

--- a/src/game/systems/ai/chase.ts
+++ b/src/game/systems/ai/chase.ts
@@ -1,0 +1,12 @@
+import type { EnemyGO } from '@/game/prefabs/enemyFactory';
+
+export function makeChase(enemy: EnemyGO, target: Phaser.GameObjects.GameObject) {
+  enemy.aiTick = (dt: number) => {
+    const t = target as any;
+    const dx = t.x - enemy.x;
+    const dy = t.y - enemy.y;
+    const len = Math.hypot(dx, dy) || 1;
+    const v = enemy.cfg.speed;
+    enemy.setVelocity((dx / len) * v, (dy / len) * v);
+  };
+}

--- a/src/game/systems/ai/kite_shoot.ts
+++ b/src/game/systems/ai/kite_shoot.ts
@@ -1,0 +1,34 @@
+import type { EnemyGO } from '@/game/prefabs/enemyFactory';
+
+export function makeKiteShoot(
+  scene: Phaser.Scene,
+  enemy: EnemyGO,
+  target: Phaser.GameObjects.GameObject,
+) {
+  let cd = 0;
+  const range = enemy.cfg.range ?? 320;
+  const rof = enemy.cfg.rof ?? 0.8;
+  enemy.aiTick = (dt: number) => {
+    const t = target as any;
+    const dx = t.x - enemy.x;
+    const dy = t.y - enemy.y;
+    const dist = Math.hypot(dx, dy);
+    // keep around 0.8*range
+    const v = enemy.cfg.speed;
+    const desired = range * 0.8;
+    const dir = dist > desired ? 1 : -1;
+    const len = Math.max(dist, 1);
+    enemy.setVelocity((dx / len) * v * dir, (dy / len) * v * dir);
+
+    cd -= dt;
+    if (cd <= 0 && dist < range) {
+      cd = 1 / rof;
+      const ang = Math.atan2(dy, dx);
+      const b = scene.physics.add.sprite(enemy.x, enemy.y, 'bullet').setCircle(3);
+      const speed = 300;
+      b.setVelocity(Math.cos(ang) * speed, Math.sin(ang) * speed);
+      (b as any).hostile = true;
+      scene.time.delayedCall(3000, () => b.destroy());
+    }
+  };
+}

--- a/src/game/systems/spawner.ts
+++ b/src/game/systems/spawner.ts
@@ -1,0 +1,30 @@
+import type { LevelCfg, SpawnCmd } from '@/types/battle';
+
+export function compileWaves(level: LevelCfg): SpawnCmd[] {
+  const out: SpawnCmd[] = [];
+  for (const w of level.waves) {
+    for (const s of w.spawns) {
+      out.push({ t: w.time, enemyId: s.enemyId, count: s.count });
+    }
+  }
+  return out.sort((a, b) => a.t - b.t);
+}
+
+export class Spawner {
+  private queue: SpawnCmd[];
+  private t = 0;
+
+  constructor(private level: LevelCfg, private emit: (enemyId: string) => void) {
+    this.queue = compileWaves(level);
+  }
+
+  update(dt: number) {
+    this.t += dt;
+    while (this.queue.length && this.queue[0].t <= this.t) {
+      const cmd = this.queue.shift()!;
+      for (let i = 0; i < cmd.count; i++) {
+        this.emit(cmd.enemyId);
+      }
+    }
+  }
+}

--- a/src/managers/EventBus.ts
+++ b/src/managers/EventBus.ts
@@ -1,0 +1,10 @@
+import Phaser from 'phaser';
+export const EventBus = new Phaser.Events.EventEmitter();
+
+export const EVT = {
+  MissionProgress: 'mission:progress',
+  MissionCompleted: 'mission:completed',
+  MissionClaimed: 'mission:claimed',
+  MissionsChanged: 'missions:changed',
+  RedDotChanged: 'reddot:changed',
+};

--- a/src/managers/MissionManager.ts
+++ b/src/managers/MissionManager.ts
@@ -1,0 +1,116 @@
+import { Storage } from '@/services/storage';
+import { fakeApi } from '@/services/network';
+import { EventBus, EVT } from './EventBus';
+import type {
+  MissionDef,
+  MissionId,
+  MissionProgress,
+  WeeklyMissionsData,
+  Reward,
+  ClaimResult,
+  ConditionType,
+} from '@/types/mission';
+import { RedDotManager } from './RedDotManager';
+
+const STORAGE_KEY = 'weekly-missions-v1';
+
+function getWeekKeyTZ(date = new Date(), tz = 'Asia/Singapore'): string {
+  const d = new Date(date.toLocaleString('en-US', { timeZone: tz }));
+  const day = d.getDay();
+  const diffToMonday = (day + 6) % 7;
+  d.setDate(d.getDate() - diffToMonday);
+  const year = d.getFullYear();
+  const start = new Date(year, 0, 1);
+  const days = Math.floor((d.getTime() - start.getTime()) / 86400000);
+  const week = Math.floor((days + ((start.getDay() + 6) % 7)) / 7) + 1;
+  return `${year}-W${String(week).padStart(2, '0')}`;
+}
+
+export class MissionManager {
+  private data: WeeklyMissionsData | null = null;
+  private defaultDefs: MissionDef[] = [];
+
+  constructor(defs: MissionDef[]) {
+    this.defaultDefs = defs;
+  }
+
+  ensureWeek(now = new Date()) {
+    const weekKey = getWeekKeyTZ(now);
+    const saved = Storage.get<WeeklyMissionsData | null>(STORAGE_KEY, null);
+    if (!saved || saved.weekKey !== weekKey) {
+      const progress: Record<MissionId, MissionProgress> = {};
+      for (const def of this.defaultDefs) {
+        progress[def.id] = { id: def.id, value: 0, claimed: false };
+      }
+      this.data = { weekKey, missions: this.defaultDefs, progress };
+      Storage.set(STORAGE_KEY, this.data);
+      EventBus.emit(EVT.MissionsChanged, this.data);
+      this.refreshRedDot();
+    } else {
+      this.data = saved;
+      this.refreshRedDot();
+    }
+  }
+
+  getAll(): WeeklyMissionsData {
+    if (!this.data) this.ensureWeek();
+    return this.data!;
+  }
+
+  addProgress(type: ConditionType, amount = 1, weaponId?: string) {
+    const data = this.getAll();
+    let changed = false;
+    for (const def of data.missions) {
+      if (def.condition.type !== type) continue;
+      if (type === 'WEAPON_KILL' && def.condition.weaponId && def.condition.weaponId !== weaponId) continue;
+      const p = data.progress[def.id];
+      const before = p.value;
+      p.value = Math.min(def.target, p.value + amount);
+      if (p.value !== before) {
+        EventBus.emit(EVT.MissionProgress, def.id, p.value, def.target);
+        if (p.value >= def.target && !p.completedAt) {
+          p.completedAt = Date.now();
+          EventBus.emit(EVT.MissionCompleted, def.id);
+        }
+        changed = true;
+      }
+    }
+    if (changed) {
+      Storage.set(STORAGE_KEY, data);
+      this.refreshRedDot();
+    }
+  }
+
+  canClaim(id: MissionId): boolean {
+    const d = this.getAll();
+    const def = d.missions.find((m) => m.id === id);
+    const p = d.progress[id];
+    return !!def && p.value >= def.target && !p.claimed;
+  }
+
+  async claim(id: MissionId): Promise<ClaimResult> {
+    const d = this.getAll();
+    const def = d.missions.find((m) => m.id === id);
+    const p = d.progress[id];
+    if (!def || !p) return { success: false, reason: 'Mission not found' };
+    if (!this.canClaim(id)) return { success: false, reason: 'Not claimable' };
+
+    const result = await fakeApi<ClaimResult>({ success: true, reward: def.reward }, 150);
+    if (result.success) {
+      p.claimed = true;
+      Storage.set(STORAGE_KEY, d);
+      EventBus.emit(EVT.MissionClaimed, id, def.reward);
+      this.refreshRedDot();
+    }
+    return result;
+  }
+
+  private refreshRedDot() {
+    const d = this.getAll();
+    const hasUnclaimed = d.missions.some((m) => {
+      const p = d.progress[m.id];
+      return p.value >= m.target && !p.claimed;
+    });
+    RedDotManager.set('missions', hasUnclaimed);
+  }
+}

--- a/src/managers/RedDotManager.ts
+++ b/src/managers/RedDotManager.ts
@@ -1,0 +1,19 @@
+import { EventBus, EVT } from './EventBus';
+
+type Channel = 'missions';
+
+class RedDotManagerImpl {
+  private state: Record<Channel, boolean> = { missions: false };
+
+  set(channel: Channel, on: boolean) {
+    if (this.state[channel] === on) return;
+    this.state[channel] = on;
+    EventBus.emit(EVT.RedDotChanged, channel, on);
+  }
+
+  get(channel: Channel) {
+    return this.state[channel];
+  }
+}
+
+export const RedDotManager = new RedDotManagerImpl();

--- a/src/services/QuestManager.ts
+++ b/src/services/QuestManager.ts
@@ -1,0 +1,117 @@
+import Phaser from 'phaser';
+import type { QuestPack, Task } from '@/types/quests';
+
+const DAILY_URL = '/quests/daily.json';
+const WEEKLY_URL = '/quests/weekly.json';
+const LS_KEY = 'phaser.quest.progress.v1';
+
+interface PersistTask extends Task { type: 'daily' | 'weekly'; }
+interface PersistData {
+  dailyResetAt: number;
+  weeklyResetAt: number;
+  tasks: Record<string, PersistTask>;
+}
+
+export class QuestManager extends Phaser.Events.EventEmitter {
+  private data: PersistData = { dailyResetAt: 0, weeklyResetAt: 0, tasks: {} };
+
+  async init() {
+    await this.resetIfNeeded();
+    const [daily, weekly] = await Promise.all([
+      fetch(DAILY_URL).then(r => r.json()) as Promise<QuestPack>,
+      fetch(WEEKLY_URL).then(r => r.json()) as Promise<QuestPack>
+    ]);
+    const stored = this.loadLS();
+    const packs: Array<{ pack: QuestPack; type: 'daily' | 'weekly' }> = [
+      { pack: daily, type: 'daily' },
+      { pack: weekly, type: 'weekly' }
+    ];
+    for (const { pack, type } of packs) {
+      for (const t of pack.tasks) {
+        const exist = stored.tasks[t.id];
+        if (!exist || exist.type !== type) {
+          stored.tasks[t.id] = { ...t, progress: 0, claimed: false, type };
+        }
+      }
+    }
+    this.data = stored;
+    this.saveLS();
+    this.emit('ready');
+  }
+
+  private loadLS(): PersistData {
+    try {
+      const raw = localStorage.getItem(LS_KEY);
+      if (raw) return JSON.parse(raw);
+    } catch {}
+    return {
+      dailyResetAt: this.todayZero(),
+      weeklyResetAt: this.weekZero(),
+      tasks: {}
+    };
+  }
+
+  private saveLS() {
+    localStorage.setItem(LS_KEY, JSON.stringify(this.data));
+    this.emit('changed');
+  }
+
+  private todayZero() {
+    const d = new Date();
+    d.setHours(0,0,0,0); return d.getTime();
+  }
+  private weekZero() {
+    const d = new Date();
+    const day = d.getDay();
+    const diff = (day === 0 ? -6 : 1 - day);
+    d.setDate(d.getDate()+diff); d.setHours(0,0,0,0);
+    return d.getTime();
+  }
+
+  private async resetIfNeeded() {
+    const now = Date.now();
+    const ls = this.loadLS();
+    const t0 = this.todayZero();
+    const w0 = this.weekZero();
+    const needDaily = now >= t0 && t0 !== ls.dailyResetAt;
+    const needWeekly = now >= w0 && w0 !== ls.weeklyResetAt;
+    if (needDaily || needWeekly) {
+      for (const t of Object.values(ls.tasks)) {
+        if (needDaily && t.type === 'daily') { t.progress = 0; t.claimed = false; }
+        if (needWeekly && t.type === 'weekly') { t.progress = 0; t.claimed = false; }
+      }
+      if (needDaily) ls.dailyResetAt = t0;
+      if (needWeekly) ls.weeklyResetAt = w0;
+      localStorage.setItem(LS_KEY, JSON.stringify(ls));
+    }
+  }
+
+  getTasks(type: 'daily' | 'weekly') {
+    return Object.values(this.data.tasks).filter(t => t.type === type);
+  }
+
+  progress(id: string, delta = 1) {
+    const t = this.data.tasks[id];
+    if (!t) return;
+    t.progress = Math.min((t.progress ?? 0) + delta, t.progressRequired);
+    this.saveLS();
+  }
+
+  canClaim(id: string) {
+    const t = this.data.tasks[id];
+    return !!t && !t.claimed && (t.progress ?? 0) >= t.progressRequired;
+  }
+
+  claim(id: string) {
+    const t = this.data.tasks[id];
+    if (!this.canClaim(id)) return false;
+    t.claimed = true;
+    this.saveLS();
+    this.emit('claimed', t);
+    return true;
+  }
+
+  badgeCount() {
+    return Object.values(this.data.tasks).filter(t => !t.claimed && (t.progress ?? 0) >= t.progressRequired).length;
+  }
+}

--- a/src/services/network.ts
+++ b/src/services/network.ts
@@ -1,0 +1,23 @@
+export async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  const ct = res.headers.get('content-type') || '';
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(`[HTTP ${res.status}] ${truncateHtml(txt)}`);
+  }
+  if (!ct.includes('application/json')) {
+    const txt = await res.text();
+    throw new Error(`[Bad Content-Type] Expect JSON, got ${ct}. Body head: ${truncateHtml(txt)}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+function truncateHtml(html: string, max = 120): string {
+  const s = html.replace(/\s+/g, ' ').trim();
+  return s.length > max ? s.slice(0, max) + '…' : s;
+}
+
+export async function fakeApi<T>(data: T, delayMs = 200): Promise<T> {
+  await new Promise((r) => setTimeout(r, delayMs));
+  return data;
+}

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,0 +1,16 @@
+export class Storage {
+  static get<T>(key: string, fallback: T): T {
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) return fallback;
+      return JSON.parse(raw) as T;
+    } catch (e) {
+      console.warn('[Storage] parse error:', e);
+      return fallback;
+    }
+  }
+
+  static set<T>(key: string, value: T): void {
+    localStorage.setItem(key, JSON.stringify(value));
+  }
+}

--- a/src/stores/battle.ts
+++ b/src/stores/battle.ts
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia';
+
+export const useBattleStore = defineStore('battle', {
+  state: () => ({
+    levelId: 'lv_1_1',
+    startedAt: 0,
+    elapsed: 0,
+    kills: 0,
+    goldGained: 0,
+    isEnded: false,
+    resultGrade: 'B' as 'S' | 'A' | 'B',
+  }),
+  actions: {
+    start(id: string) {
+      this.levelId = id;
+      this.startedAt = Date.now();
+      this.elapsed = 0;
+      this.kills = 0;
+      this.goldGained = 0;
+      this.isEnded = false;
+    },
+    tick(dt: number) {
+      this.elapsed += dt;
+    },
+    addKill() {
+      this.kills++;
+    },
+    addGold(n: number) {
+      this.goldGained += n;
+    },
+    end(grade: 'S' | 'A' | 'B') {
+      this.isEnded = true;
+      this.resultGrade = grade;
+    },
+  },
+});

--- a/src/stores/player.ts
+++ b/src/stores/player.ts
@@ -1,0 +1,24 @@
+import { defineStore } from 'pinia';
+
+export const usePlayerStore = defineStore('player', {
+  state: () => ({
+    level: 1,
+    exp: 0,
+    gold: 0,
+    stats: {
+      atk: 10,
+      hp: 100,
+      def: 0,
+      critRate: 0.05,
+      critDmg: 1.5,
+      ms: 1,
+      as: 1,
+      cdr: 0
+    }
+  }),
+  actions: {
+    addGold(n: number) {
+      this.gold += n;
+    }
+  }
+});

--- a/src/stores/quests.ts
+++ b/src/stores/quests.ts
@@ -1,0 +1,57 @@
+import { defineStore } from 'pinia';
+import {
+  questsService,
+  type QuestDef,
+  type DailyProgress,
+} from '@/core/quests/quests.service';
+
+export const useQuestsStore = defineStore('quests', {
+  state: () => ({
+    defs: [] as QuestDef[],
+    progress: { dateKey: '', counters: {}, claimed: [] } as DailyProgress,
+    loaded: false,
+  }),
+  getters: {
+    list(state) {
+      return state.defs.map((q) => ({
+        ...q,
+        done: (state.progress.counters[q.id] ?? 0) >= q.goal,
+        claimed: state.progress.claimed.includes(q.id),
+        value: state.progress.counters[q.id] ?? 0,
+      }));
+    },
+  },
+  actions: {
+    async init() {
+      if (this.loaded) return;
+      const defs = await questsService.loadDefs();
+      this.defs = defs.daily;
+      this.progress = await questsService.loadProgress();
+      this.loaded = true;
+    },
+    add(id: string, delta = 1) {
+      const cur = this.progress.counters[id] ?? 0;
+      const goal = this.defs.find((d) => d.id === id)?.goal ?? cur + delta;
+      this.progress.counters[id] = Math.min(cur + delta, goal);
+      questsService.saveProgress(this.progress);
+    },
+    onWin() {
+      this.add('d_win2', 1);
+    },
+    onKills(n: number) {
+      this.add('d_kill150', n);
+    },
+    onWeaponFamilyRun() {
+      this.add('d_weapon_family', 1);
+    },
+    async claim(id: string) {
+      const q = this.defs.find((d) => d.id === id);
+      if (!q) return;
+      const done = (this.progress.counters[id] ?? 0) >= q.goal;
+      if (!done || this.progress.claimed.includes(id)) return;
+      await questsService.grantReward(q.reward);
+      this.progress.claimed.push(id);
+      await questsService.saveProgress(this.progress);
+    },
+  },
+});

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/types/battle.ts
+++ b/src/types/battle.ts
@@ -1,0 +1,23 @@
+export interface SpawnCmd { t: number; enemyId: string; count: number }
+export interface LevelWave { time: number; spawns: { enemyId: string; count: number }[] }
+export interface LevelCfg {
+  id: string;
+  name: string;
+  mode: 'survival' | 'clear';
+  duration: number;
+  waves: LevelWave[];
+  difficultyScale: number;
+}
+
+export interface EnemyCfg {
+  id: string;
+  hp: number;
+  atk: number;
+  speed: number;
+  ai: string;
+  range?: number;
+  rof?: number;
+}
+
+export type DropItem = { item: string; min: number; max: number; weight: number };
+export type DropTable = Record<string, DropItem[]>;

--- a/src/types/mission.ts
+++ b/src/types/mission.ts
@@ -1,0 +1,43 @@
+export type MissionId = string;
+
+export type ConditionType = 'KILL' | 'WINS' | 'WEAPON_KILL';
+
+export interface Condition {
+  type: ConditionType;
+  weaponId?: string; // only for WEAPON_KILL
+}
+
+export interface Reward {
+  coins?: number;
+  gems?: number;
+  itemId?: string;
+  amount?: number;
+}
+
+export interface MissionDef {
+  id: MissionId;
+  title: string;
+  desc: string;
+  target: number;
+  condition: Condition;
+  reward: Reward;
+}
+
+export interface MissionProgress {
+  id: MissionId;
+  value: number; // current progress value
+  completedAt?: number; // epoch ms
+  claimed?: boolean;
+}
+
+export interface WeeklyMissionsData {
+  weekKey: string; // e.g. 2025-W33
+  missions: MissionDef[];
+  progress: Record<MissionId, MissionProgress>;
+}
+
+export interface ClaimResult {
+  success: boolean;
+  reward?: Reward;
+  reason?: string;
+}

--- a/src/types/quests.d.ts
+++ b/src/types/quests.d.ts
@@ -1,0 +1,13 @@
+export type Task = {
+  id: string;
+  title: string;
+  progressRequired: number;
+  progress?: number;
+  claimed?: boolean;
+};
+
+export type QuestPack = {
+  version: number;
+  reset: 'daily' | 'weekly';
+  tasks: Task[];
+};

--- a/src/ui/App.vue
+++ b/src/ui/App.vue
@@ -1,0 +1,5 @@
+<template>
+  <router-view />
+</template>
+<script setup lang="ts">
+</script>

--- a/src/ui/MissionButton.ts
+++ b/src/ui/MissionButton.ts
@@ -1,0 +1,66 @@
+import Phaser from 'phaser';
+import { RedDotManager } from '@/managers/RedDotManager';
+import { EventBus, EVT } from '@/managers/EventBus';
+
+export class MissionButton extends Phaser.GameObjects.Container {
+  private bg: Phaser.GameObjects.RoundRectangle;
+  private label: Phaser.GameObjects.Text;
+  private dot: Phaser.GameObjects.Ellipse;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, text = 'Missions') {
+    super(scene, x, y);
+
+    this.bg = scene.add
+      .roundRectangle(0, 0, 120, 40, 12, 0x2b2f3a, 0.8)
+      .setStrokeStyle(2, 0x8aa0ff, 1)
+      .setOrigin(0.5);
+
+    this.label = scene.add
+      .text(0, 0, text, { fontFamily: 'Arial', fontSize: '16px' })
+      .setOrigin(0.5);
+
+    this.dot = scene.add
+      .ellipse(50, -14, 14, 14, 0xff3b30, 1)
+      .setScale(0)
+      .setDepth(2);
+
+    this.add([this.bg, this.label, this.dot]);
+
+    this.setSize(120, 40);
+    this.setInteractive(
+      new Phaser.Geom.Rectangle(-60, -20, 120, 40),
+      Phaser.Geom.Rectangle.Contains,
+    )
+      .on('pointerover', () => this.bg.setFillStyle(0x323949, 0.9))
+      .on('pointerout', () => this.bg.setFillStyle(0x2b2f3a, 0.8));
+
+    EventBus.on(EVT.RedDotChanged, (channel: string, on: boolean) => {
+      if (channel === 'missions') this.updateDot(on);
+    });
+
+    this.updateDot(RedDotManager.get('missions'));
+  }
+
+  updateDot(on: boolean) {
+    const target = on ? 1 : 0;
+    this.scene.tweens.add({
+      targets: this.dot,
+      scale: target,
+      duration: 240,
+      ease: 'Back.Out',
+    });
+
+    if (on) {
+      this.scene.tweens.add({
+        targets: this.dot,
+        scale: { from: 0.92, to: 1.1 },
+        yoyo: true,
+        repeat: -1,
+        duration: 800,
+        ease: 'Sine.InOut',
+      });
+    } else {
+      this.scene.tweens.killTweensOf(this.dot);
+    }
+  }
+}

--- a/src/ui/MissionPanel.ts
+++ b/src/ui/MissionPanel.ts
@@ -1,0 +1,141 @@
+import Phaser from 'phaser';
+import type { MissionManager } from '@/managers/MissionManager';
+import type { MissionDef, WeeklyMissionsData } from '@/types/mission';
+import { EventBus, EVT } from '@/managers/EventBus';
+import { playRewardAnimation } from '@/effects/RewardAnimation';
+
+export class MissionPanel extends Phaser.GameObjects.Container {
+  private bg!: Phaser.GameObjects.RoundRectangle;
+  private title!: Phaser.GameObjects.Text;
+  private closeBtn!: Phaser.GameObjects.Text;
+  private list!: Phaser.GameObjects.Container;
+  private mm: MissionManager;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, mm: MissionManager) {
+    super(scene, x, y);
+    this.mm = mm;
+    this.build();
+    this.refresh();
+
+    EventBus.on(EVT.MissionsChanged, () => this.refresh());
+    EventBus.on(EVT.MissionProgress, () => this.refresh());
+    EventBus.on(EVT.MissionClaimed, () => this.refresh());
+  }
+
+  private build() {
+    const w = 480,
+      h = 360;
+    this.bg = this.scene.add
+      .roundRectangle(0, 0, w, h, 18, 0x1f232b, 0.95)
+      .setStrokeStyle(2, 0x475569, 1)
+      .setOrigin(0.5);
+    this.title = this.scene.add
+      .text(0, -h / 2 + 24, 'Weekly Missions', { fontSize: '20px', fontFamily: 'Arial' })
+      .setOrigin(0.5, 0.5);
+    this.closeBtn = this.scene.add
+      .text(w / 2 - 28, -h / 2 + 16, '✕', { fontSize: '18px' })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on('pointerup', () => this.setVisible(false));
+
+    this.list = this.scene.add.container(-w / 2 + 16, -h / 2 + 52);
+
+    this.add([this.bg, this.title, this.closeBtn, this.list]);
+    this.setVisible(false);
+  }
+
+  private clearList() {
+    this.list.removeAll(true);
+  }
+
+  private addMissionItem(def: MissionDef, y: number, data: WeeklyMissionsData) {
+    const p = data.progress[def.id];
+
+    const g = this.scene.add.graphics();
+    g.fillStyle(0x242a33, 0.85);
+    g.fillRoundedRect(0, y, 448, 76, 12);
+
+    const barX = 16,
+      barY = y + 40,
+      barW = 300,
+      barH = 14;
+    g.fillStyle(0x1b2028, 1);
+    g.fillRoundedRect(barX, barY, barW, barH, 7);
+
+    const ratio = Math.min(1, p.value / def.target);
+    g.fillStyle(0x7c9cff, 1);
+    g.fillRoundedRect(barX, barY, Math.max(8, Math.floor(barW * ratio)), barH, 7);
+
+    const title = this.scene.add.text(16, y + 12, def.title, { fontSize: '16px', fontFamily: 'Arial' });
+    const desc = this.scene.add.text(16, y + 28, def.desc, { fontSize: '12px', color: '#9aa4b2' });
+    const counter = this.scene.add.text(barX + barW + 12, barY - 4, `${p.value}/${def.target}`, {
+      fontSize: '14px',
+    });
+
+    const claimable = p.value >= def.target && !p.claimed;
+    const claimed = p.claimed === true;
+
+    const btn = this.createButton(364, y + 20, claimed ? 'Claimed' : claimable ? 'Claim' : 'Go');
+    if (claimable) {
+      btn.on('pointerup', async () => {
+        btn.disableInteractive();
+        const result = await this.mm.claim(def.id);
+        if (result.success && result.reward) {
+          const globalStart = this.getGlobalCenterOf(btn);
+          const globalEnd = this.getGlobalBagIconPos();
+          await playRewardAnimation(
+            this.scene,
+            globalStart.x,
+            globalStart.y,
+            globalEnd.x,
+            globalEnd.y,
+          );
+        }
+        btn.setInteractive({ useHandCursor: true });
+      });
+    } else if (!claimed) {
+      btn.on('pointerup', () => {
+        this.scene
+          .add.text(this.x - 200, this.y + 160, 'Play any mode to progress!', {
+            fontSize: '12px',
+            color: '#cbd5e1',
+          })
+          .setDepth(999)
+          .setAlpha(0)
+          .setScrollFactor(0);
+      });
+    }
+
+    this.list.add([g, title, desc, counter, btn]);
+  }
+
+  private createButton(x: number, y: number, text: string) {
+    const bg = this.scene.add
+      .roundRectangle(x, y, 84, 32, 8, 0x2b3340, 1)
+      .setStrokeStyle(2, 0x7c9cff)
+      .setInteractive({ useHandCursor: true });
+    const label = this.scene.add.text(x, y, text, { fontSize: '14px' }).setOrigin(0.5);
+    const c = this.scene.add.container(0, 0, [bg, label]);
+    return c.setSize(84, 32).setInteractive(new Phaser.Geom.Rectangle(x - 42, y - 16, 84, 32), () => true);
+  }
+
+  private getGlobalCenterOf(obj: Phaser.GameObjects.Container) {
+    const bounds = obj.getBounds();
+    return obj.getWorldTransformMatrix().apply(bounds.centerX, bounds.centerY, { x: 0, y: 0 });
+  }
+
+  private getGlobalBagIconPos() {
+    const cam = this.scene.cameras.main;
+    return { x: cam.worldView.x + cam.width - 60, y: cam.worldView.y + 50 };
+  }
+
+  refresh() {
+    this.clearList();
+    const data = this.mm.getAll();
+    let y = 0;
+    for (const def of data.missions) {
+      this.addMissionItem(def, y, data);
+      y += 84;
+    }
+  }
+}

--- a/src/ui/components/QuestsPanel.vue
+++ b/src/ui/components/QuestsPanel.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import { useQuestsStore } from '@/stores/quests';
+const qs = useQuestsStore();
+onMounted(() => qs.init());
+</script>
+
+<template>
+  <div class="p-4 space-y-4">
+    <h2 class="text-xl font-bold">每日任务</h2>
+    <div class="text-sm text-gray-400">
+      重置时间：本地每日 00:00（当前批次：{{ qs.progress.dateKey }})
+    </div>
+
+    <div
+      v-for="q in qs.list"
+      :key="q.id"
+      class="p-3 rounded-lg border border-gray-700/40 bg-black/30"
+    >
+      <div class="flex items-center justify-between">
+        <div class="font-medium">{{ q.desc }}</div>
+        <div class="text-sm">{{ q.value }} / {{ q.goal }}</div>
+      </div>
+      <div class="w-full h-2 mt-2 rounded bg-gray-700/50">
+        <div
+          class="h-2 rounded bg-blue-500"
+          :style="{ width: Math.min(100, Math.floor((q.value / q.goal) * 100)) + '%' }"
+        ></div>
+      </div>
+      <div class="mt-3 flex items-center justify-between">
+        <div class="text-xs text-gray-400">
+          奖励：
+          <span v-for="(v, k) in q.reward" :key="k" class="mr-2">{{ k }}×{{ v }}</span>
+        </div>
+        <button
+          class="px-3 py-1 rounded text-white"
+          :class="
+            q.claimed
+              ? 'bg-gray-600 cursor-not-allowed'
+              : q.done
+              ? 'bg-green-600'
+              : 'bg-gray-700 cursor-not-allowed'
+          "
+          :disabled="!q.done || q.claimed"
+          @click="$event.stopPropagation(); qs.claim(q.id)"
+        >
+          {{ q.claimed ? '已领取' : q.done ? '领取' : '未完成' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/ui/pages/Battle.vue
+++ b/src/ui/pages/Battle.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount } from 'vue';
+import Phaser from 'phaser';
+import { GameScene } from '@/game/scenes/GameScene';
+import { BootScene } from '@/game/scenes/BootScene';
+import { ResultScene } from '@/game/scenes/ResultScene';
+import UIScene from '@/game/scenes/UIScene';
+
+let game: Phaser.Game | null = null;
+const config: Phaser.Types.Core.GameConfig = {
+  type: Phaser.AUTO,
+  parent: 'phaser-root',
+  width: 960,
+  height: 540,
+  backgroundColor: '#000000',
+  physics: {
+    default: 'arcade',
+    arcade: { gravity: { y: 0 }, debug: false },
+  },
+  scene: [BootScene, GameScene, UIScene, ResultScene],
+};
+
+onMounted(() => {
+  game = new Phaser.Game(config);
+});
+onBeforeUnmount(() => {
+  game?.destroy(true);
+  game = null;
+});
+</script>
+
+<template>
+  <div class="p-2 h-[calc(100vh-64px)]">
+    <div id="phaser-root" class="w-full h-full rounded-xl overflow-hidden bg-black" />
+  </div>
+</template>

--- a/src/ui/pages/Home.vue
+++ b/src/ui/pages/Home.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { saveService } from '@/core/save/save.service';
+
+const gold = ref(0);
+onMounted(async () => {
+  const data = await saveService.get<any>('slot1');
+  gold.value = data?.inventory?.gold ?? 0;
+});
+</script>
+
+<template>
+  <div class="p-6 space-y-4">
+    <h1 class="text-2xl font-bold">基地</h1>
+    <div>金币：<b>{{ gold }}</b></div>
+    <router-link to="/battle" class="px-4 py-2 bg-blue-600 text-white rounded">
+      开始战斗
+    </router-link>
+    <router-link
+      to="/quests"
+      class="px-4 py-2 bg-slate-700 text-white rounded inline-block ml-3"
+    >
+      每日任务
+    </router-link>
+  </div>
+</template>

--- a/src/ui/pages/Quests.vue
+++ b/src/ui/pages/Quests.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import QuestsPanel from '@/ui/components/QuestsPanel.vue';
+</script>
+
+<template>
+  <div class="max-w-3xl mx-auto p-6">
+    <QuestsPanel />
+  </div>
+</template>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{vue,ts,tsx}'],
+  theme: { extend: {} },
+  plugins: []
+};

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('math', () => {
+  it('adds', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [{ "path": "tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import { VitePWA } from 'vite-plugin-pwa';
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      manifest: {
+        name: 'Shooter Raising',
+        short_name: 'SR',
+        start_url: '/',
+        display: 'standalone',
+        icons: []
+      },
+      workbox: {
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,webp,mp3,ogg}']
+      }
+    })
+  ],
+  resolve: {
+    alias: {
+      '@': '/src'
+    }
+  },
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- add weekly mission management with local persistence and red-dot notifications
- introduce safe JSON fetching and reward animation helpers
- integrate mission UI and camera bounds checks into GameScene

## Testing
- `npm test` *(vitest: not found)*
- `npm run lint` *(ESLint configuration not found)*
- `npm run build` *(vite: not found)*
- `npm run prepare` *(husky: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d8c3cea5483278d6eb46d1f223aa8