### PR TITLE
feat: add safe json fetch

### DIFF
--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -1,24 +1,22 @@
 import { z } from 'zod';
+import { fetchJSON } from '@/services/network';
 
 export const LevelWave = z.object({
   time: z.number().nonnegative(),
-  spawns: z.array(
-    z.object({ enemyId: z.string(), count: z.number().int().positive() })
-  )
+  spawns: z.array(z.object({ enemyId: z.string(), count: z.number().int().positive() })),
 });
 export const LevelCfg = z.object({
   id: z.string(),
   name: z.string(),
   waves: z.array(LevelWave),
-  difficultyScale: z.number().positive().default(1)
+  difficultyScale: z.number().positive().default(1),
 });
 export type LevelCfg = z.infer<typeof LevelCfg>;
 
 export class ConfigService {
   private cache = new Map<string, unknown>();
   async loadJson<T>(url: string, schema: z.ZodType<T>): Promise<T> {
-    const res = await fetch(url);
-    const json = await res.json();
+    const json = await fetchJSON<unknown>(url);
     const parsed = schema.parse(json);
     this.cache.set(url, parsed);
     return parsed;

--- a/src/core/config/config.service.ts
+++ b/src/core/config/config.service.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { fetchJSON } from '@/services/network';
+import { fetchJSON } from '../../services/network';
 
 export const LevelWave = z.object({
   time: z.number().nonnegative(),

--- a/src/services/network.ts
+++ b/src/services/network.ts
@@ -1,15 +1,18 @@
 export async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, init);
   const ct = res.headers.get('content-type') || '';
+  const txt = await res.text();
   if (!res.ok) {
-    const txt = await res.text();
     throw new Error(`[HTTP ${res.status}] ${truncateHtml(txt)}`);
   }
   if (!ct.includes('application/json')) {
-    const txt = await res.text();
     throw new Error(`[Bad Content-Type] Expect JSON, got ${ct}. Body head: ${truncateHtml(txt)}`);
   }
-  return res.json() as Promise<T>;
+  try {
+    return JSON.parse(txt) as T;
+  } catch {
+    throw new Error(`[Invalid JSON] ${truncateHtml(txt)}`);
+  }
 }
 
 function truncateHtml(html: string, max = 120): string {

--- a/src/services/network.ts
+++ b/src/services/network.ts
@@ -1,0 +1,23 @@
+export async function fetchJSON<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, init);
+  const ct = res.headers.get('content-type') || '';
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(`[HTTP ${res.status}] ${truncateHtml(txt)}`);
+  }
+  if (!ct.includes('application/json')) {
+    const txt = await res.text();
+    throw new Error(`[Bad Content-Type] Expect JSON, got ${ct}. Body head: ${truncateHtml(txt)}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+function truncateHtml(html: string, max = 120): string {
+  const s = html.replace(/\s+/g, ' ').trim();
+  return s.length > max ? s.slice(0, max) + '…' : s;
+}
+
+export async function fakeApi<T>(data: T, delayMs = 200): Promise<T> {
+  await new Promise((r) => setTimeout(r, delayMs));
+  return data;
+}

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,0 +1,16 @@
+export class Storage {
+  static get<T>(key: string, fallback: T): T {
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) return fallback;
+      return JSON.parse(raw) as T;
+    } catch (e) {
+      console.warn('[Storage] parse error:', e);
+      return fallback;
+    }
+  }
+
+  static set<T>(key: string, value: T): void {
+    localStorage.setItem(key, JSON.stringify(value));
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,6 @@
 import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
 import { VitePWA } from 'vite-plugin-pwa';
-import { createRequire } from 'module';
-
-// Use require() to load the Vue plugin's CommonJS build. This avoids
-// Node's ESM named export check against the installed Vue package and
-// prevents "does not provide an export named 'computed'" errors.
-const require = createRequire(import.meta.url);
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const vue = require('@vitejs/plugin-vue');
 
 export default defineConfig({
   plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'vite';
-import vue from '@vitejs/plugin-vue';
 import { VitePWA } from 'vite-plugin-pwa';
+import { createRequire } from 'module';
+
+// Use require() to load the Vue plugin's CommonJS build. This avoids
+// Node's ESM named export check against the installed Vue package and
+// prevents "does not provide an export named 'computed'" errors.
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const vue = require('@vitejs/plugin-vue');
 
 export default defineConfig({
   plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from 'vite';
+// Import the Vue plugin via its ESM entry. Using the CJS build triggers missing
+// `@vue/compiler-core` errors on some setups when Vite bundles the config.
 import vue from '@vitejs/plugin-vue';
 import { VitePWA } from 'vite-plugin-pwa';
 


### PR DESCRIPTION
## Summary
- add storage helper and safe JSON fetch helper for network calls
- use safe fetch in config service to validate responses before parsing

## Testing
- `npm test`
- `npm run typecheck` (fails: Cannot find module '@/stores/battle' etc.)
- `npm run lint` (fails: Unexpected any in existing files)


------
https://chatgpt.com/codex/tasks/task_e_689db42beffc8327a33eebf2074f9f3c